### PR TITLE
Switch UI to use proxied API paths, switch proxy to use internal `.local` URLs, disable HTTPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,5 @@ COPY --from=builder /virt-ui/node_modules /opt/app-root/src/node_modules
 COPY --from=builder /virt-ui/package.json /opt/app-root/src
 
 ENV VIRTMETA_FILE="/etc/virt-ui/virtMeta.json"
-ENV NODE_TLS_REJECT_UNAUTHORIZED="0"
 
 ENTRYPOINT ["npm", "run", "-d", "start"]

--- a/deploy/server.js
+++ b/deploy/server.js
@@ -72,46 +72,49 @@ if (process.env['DATA_SOURCE'] !== 'mock') {
 }
 
 let clusterApiProxyOptions = {
-  target: virtMeta.clusterApi,
+  target: 'https://api.openshift-apiserver.svc.cluster.local',
   changeOrigin: true,
   pathRewrite: {
     '^/cluster-api/': '/',
   },
+  secure: false,
 };
 
 let inventoryApiProxyOptions = {
-  target: virtMeta.inventoryApi,
+  target: 'http://inventory.openshift-migration.svc.cluster.local',
   changeOrigin: true,
   pathRewrite: {
     '^/inventory-api/': '/',
   },
+  secure: false,
 };
 
 let inventoryPayloadApiProxyOptions = {
-  target: virtMeta.inventoryPayloadApi,
+  target: 'http://inventory-payload.openshift-migration.svc.cluster.local:8080',
   changeOrigin: true,
   pathRewrite: {
     '^/inventory-payload-api/': '/',
   },
+  secure: false,
 };
 
 if (process.env['NODE_ENV'] === 'development') {
   clusterApiProxyOptions = {
     ...clusterApiProxyOptions,
+    target: virtMeta.clusterApi,
     logLevel: 'debug',
-    secure: false,
   };
 
   inventoryApiProxyOptions = {
     ...inventoryApiProxyOptions,
+    target: virtMeta.inventoryApi,
     logLevel: 'debug',
-    secure: false,
   };
 
   inventoryPayloadApiProxyOptions = {
+    target: virtMeta.inventoryPayloadApi,
     ...inventoryPayloadApiProxyOptions,
     logLevel: 'debug',
-    secure: false,
   };
 }
 

--- a/scripts/run-local-express.sh
+++ b/scripts/run-local-express.sh
@@ -2,7 +2,6 @@
 _dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export VIRTMETA_FILE="$_dir/../config/virtMeta.dev.json"
 export STATIC_DIR="$_dir/../dist"
-export NODE_TLS_REJECT_UNAUTHORIZED="0"
 mkdir -p "$STATIC_DIR"
 cd $_dir/..
 if [ "$1" == "--auto-reload" ]; then

--- a/src/app/Providers/components/ProvidersTable/VMware/VMwareProvidersTable.tsx
+++ b/src/app/Providers/components/ProvidersTable/VMware/VMwareProvidersTable.tsx
@@ -63,9 +63,9 @@ const VMwareProvidersTable: React.FunctionComponent<IVMwareProvidersTableProps> 
     isEqual: (a, b) => a.name === b.name,
   });
 
-  const inventoryDownloadURL = `${
-    VIRT_META.inventoryPayloadApi
-  }/api/v1/extract?providers=${selectedItems.map((provider) => provider.name).join()}`;
+  const inventoryDownloadURL = `/inventory-payload-api/api/v1/extract?providers=${selectedItems
+    .map((provider) => provider.name)
+    .join()}`;
 
   const columns: ICell[] = [
     {

--- a/src/app/client/helpers.ts
+++ b/src/app/client/helpers.ts
@@ -192,5 +192,5 @@ export const useClientInstance = (): KubeClient.ClusterClient => {
     access_token: currentUserString.access_token,
     expiry_time: currentUserString.expiry_time,
   };
-  return ClientFactory.cluster(user, VIRT_META.clusterApi);
+  return ClientFactory.cluster(user, '/cluster-api');
 };

--- a/src/app/queries/helpers.ts
+++ b/src/app/queries/helpers.ts
@@ -81,8 +81,7 @@ export const useMockableMutation = <
   );
 };
 
-export const getInventoryApiUrl = (relativePath: string): string =>
-  `${VIRT_META.inventoryApi}${relativePath}`;
+export const getInventoryApiUrl = (relativePath: string): string => `/inventory-api${relativePath}`;
 
 export const getAggregateQueryStatus = (
   queryResults: (QueryResult<unknown> | MutationResult<unknown>)[]


### PR DESCRIPTION
A PR to address feedback in #214. @gildub this is targeting your branch, so if you approve of these additional commits you can just merge this PR and it will update your PR.

* Changes URLs used in the UI code to use the proxied URLs instead of VIRT_META values
* Changes server.js to use internal `.local` URLs when running in prod mode
* Disables HTTPS for all API calls and removes the `NODE_TLS_REJECT_UNAUTHORIZED` env variable
  * In prod mode, we'll be using local `http://` URLs in the pod network, so we don't need SSL.
  * In dev mode, we want to ignore the self-signed certs, so we don't need SSL.